### PR TITLE
Add tab bar layout + link file tree's behaviors to tab bar's behaviors

### DIFF
--- a/nimbus/app/page.tsx
+++ b/nimbus/app/page.tsx
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import Editor from "@monaco-editor/react";
 import { FileTree, type TreeNode } from "@/components/FileTree";
+import { TabBar, type OpenFileTab } from "@/components/TabBar";
 import { useFileManager } from "@/components/hooks/useFileManager"
 import Link from "next/link";
 
+// File structure for the file explorer. In a real app, this would come from the backend or filesystem.
 const sampleFileTree: TreeNode[] = [
   {
     name: "app",
@@ -103,7 +105,6 @@ export default {
   },
 ];
 
-
 export default function App() {
   const {
     code,
@@ -121,12 +122,149 @@ export default function App() {
   const [theme] = useState<string>("vs-dark");
   const [activeFilePath, setActiveFilePath] = useState<string>();
 
+  // File tree section:
+  // --------------------------------------------------------------------------------
+  // Handle Single Click on file in FileTree: open in "preview" mode (reusing same tab) 
+  // and mark as dirty on edit.
   const handleSelectFile = (node: TreeNode, path: string) => {
-    openVirtualFile({
+    const nextFile: OpenFileTab = {
+      id: path,
       name: node.name,
       contents: node.content ?? "",
+      isDirty: false,
+      isPreview: true,
+    }
+
+    setOpenFiles((files) => {
+      const alreadyOpen = files.some((file) => file.id === path);
+
+      if (alreadyOpen) {
+        return files;
+      }
+
+      const activeFile = files.find((file) => file.id === activeFileId);
+
+      if (activeFile?.isPreview) {
+        return files.map((file) =>
+          file.id === activeFileId ? nextFile : file
+        );
+      }
+
+      return [...files, nextFile];
     });
+    
+    LoadFileHelper(path, nextFile);
+    
+  };
+
+  // Handle Double Click on file in FileTree: open in "normal" mode (new tab if preview, 
+  // or reuse if already open) and mark as dirty on edit.
+  const handleOpenFile = (node: TreeNode, path: string) => {
+    const nextFile: OpenFileTab = {
+      id: path,
+      name: node.name,
+      contents: node.content ?? "",
+      isDirty: false,
+      isPreview: false,
+    }
+
+    setOpenFiles((files) => {
+      const alreadyOpen = files.some((file) => file.id === path);
+
+      if (alreadyOpen) {
+        return files.map((file) =>
+          file.id === path ? { ...file, isPreview: false } : file
+        );
+      }
+
+      return [...files, nextFile];
+    });
+
+    LoadFileHelper(path, nextFile);
+  }
+
+  // Help set which file is active in the editor and open it in the file manager 
+  // (which tracks dirty state, etc.)
+  function LoadFileHelper(path: string, nextFile: OpenFileTab) {
+    setActiveFileId(path);
     setActiveFilePath(path);
+
+    openVirtualFile({
+      name: nextFile.name,
+      contents: nextFile.contents,
+    });
+  }
+
+  // Tab bar section:
+  // --------------------------------------------------------------------------------
+  const [openFiles, setOpenFiles] = useState<OpenFileTab[]>([
+     {
+      id: "temp.py",
+      name: "temp.py",
+      contents: code,
+      isDirty: false,
+      isPreview: false,
+    },
+  ]);
+  const [activeFileId, setActiveFileId] = useState<string>("temp.py");
+
+  // Hardcoded file tabs for demo:
+  // const [openFiles, setOpenFiles] = useState<OpenFileTab[]>([
+  //   {
+  //     id: "app/page.tsx",
+  //     name: "page.tsx",
+  //     contents: `export default function HomePage() {
+  //   return <main>Welcome to Nimbus.</main>;
+  // }
+  // `,
+  //     isDirty: false,
+  //   },
+  //   {
+  //     id: "app/layout.tsx",
+  //     name: "layout.tsx",
+  //     contents: `export default function RootLayout({
+  //   children,
+  // }: {
+  //   children: React.ReactNode;
+  // }) {
+  //   return <html lang="en"><body>{children}</body></html>;
+  // }
+  // `,
+  //     isDirty: false,
+  //   },
+  //   {
+  //     id: "components/FileTree.tsx",
+  //     name: "FileTree.tsx",
+  //     contents: `export function FileTree() {
+  //   return <nav aria-label="Project files" />;
+  // }
+  // `,
+  //     isDirty: true,
+  //   },
+  //   {
+  //     id: "package.json",
+  //     name: "package.json",
+  //     contents: `{
+  //   "name": "nimbus",
+  //   "private": true
+  // }
+  // `,
+  //     isDirty: false,
+  //   },
+  // ]);
+  // const [activeFileId, setActiveFileId] = useState<string>("app/page.tsx");
+
+  // Handle click on tab in TabBar: switch to that file and open in file manager
+  const handleSelectTab = (id: string) => {
+    const file = openFiles.find((file) => file.id === id);
+    if (!file) return;
+
+    setActiveFileId(file.id);
+    setActiveFilePath(file.id);
+    openVirtualFile({
+      name: file.name,
+      contents: file.contents,
+    });
   };
 
   // Basic layout: sidebar for file explorer + main editor area with header
@@ -134,7 +272,6 @@ export default function App() {
   return (
     <div className="h-screen flex overflow-hidden">
       {/* Static sidebar for file explorer */}
-      {/* TODO: implementing file tree */}
       <aside className="w-[15vw] shrink-0 bg-neutral-900 text-neutral-100">
         <header className="h-12 px-4 flex items-center border-b border-neutral-800">
           Explorer
@@ -143,6 +280,7 @@ export default function App() {
               nodes={sampleFileTree}
               activePath={activeFilePath}
               onSelectFile={handleSelectFile}
+              onOpenFile={handleOpenFile}
             />
       </aside>
 
@@ -150,10 +288,6 @@ export default function App() {
       <main className="flex-1 min-w-0 flex flex-col">
         <header className="p-3 border-b flex items-center gap-2">
           <span className="font-semibold">VS Lite — Editor</span>
-          <span className="text-sm text-gray-500">
-            {fileName}
-            {isDirty ? " •" : ""}
-          </span>
 
           <div className="ml-auto flex items-center gap-2">
             <button className="px-3 py-1 border rounded" onClick={openFile}>
@@ -179,17 +313,35 @@ export default function App() {
           <input {...fileInputProps} suppressHydrationWarning/>
         </header>
   
+        {/* Tab bar for open files */}
+        <TabBar
+          files={openFiles}
+          activeFileId={activeFileId ?? ""}
+          onSelectFile={handleSelectTab}
+        />
+
         <div className="flex-1 min-h-0">
           <Editor
             height="100%"
             language={language} // tracks extension (e.g., .py -> python)
             theme={theme}
             value={code}
-            onChange={(v) => setCode(v ?? "")}
+            onChange={(v) => {
+              const nextCode = v ?? "";
+              setCode(nextCode);
+              setOpenFiles((files) =>
+                files.map((file) =>
+                  file.id === activeFileId
+                    ? { ...file, contents: nextCode, isDirty: true }
+                    : file
+                )
+              );
+            }}
             options={{ fontSize: 14, minimap: { enabled: false } }}
           />
         </div>
       </main>
     </div>
   );
+
 }

--- a/nimbus/app/page.tsx
+++ b/nimbus/app/page.tsx
@@ -208,52 +208,6 @@ export default function App() {
   ]);
   const [activeFileId, setActiveFileId] = useState<string>("temp.py");
 
-  // Hardcoded file tabs for demo:
-  // const [openFiles, setOpenFiles] = useState<OpenFileTab[]>([
-  //   {
-  //     id: "app/page.tsx",
-  //     name: "page.tsx",
-  //     contents: `export default function HomePage() {
-  //   return <main>Welcome to Nimbus.</main>;
-  // }
-  // `,
-  //     isDirty: false,
-  //   },
-  //   {
-  //     id: "app/layout.tsx",
-  //     name: "layout.tsx",
-  //     contents: `export default function RootLayout({
-  //   children,
-  // }: {
-  //   children: React.ReactNode;
-  // }) {
-  //   return <html lang="en"><body>{children}</body></html>;
-  // }
-  // `,
-  //     isDirty: false,
-  //   },
-  //   {
-  //     id: "components/FileTree.tsx",
-  //     name: "FileTree.tsx",
-  //     contents: `export function FileTree() {
-  //   return <nav aria-label="Project files" />;
-  // }
-  // `,
-  //     isDirty: true,
-  //   },
-  //   {
-  //     id: "package.json",
-  //     name: "package.json",
-  //     contents: `{
-  //   "name": "nimbus",
-  //   "private": true
-  // }
-  // `,
-  //     isDirty: false,
-  //   },
-  // ]);
-  // const [activeFileId, setActiveFileId] = useState<string>("app/page.tsx");
-
   // Handle click on tab in TabBar: switch to that file and open in file manager
   const handleSelectTab = (id: string) => {
     const file = openFiles.find((file) => file.id === id);

--- a/nimbus/components/FileTree.tsx
+++ b/nimbus/components/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export type TreeNode = {
   name: string;
@@ -11,6 +11,7 @@ type FileTreeProps = {
   nodes: TreeNode[];
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
+  onOpenFile?: (node: TreeNode, path: string) => void;
 };
 
 type TreeNodeRowProps = {
@@ -19,16 +20,20 @@ type TreeNodeRowProps = {
   path: string;
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
+  onOpenFile?: (node: TreeNode, path: string) => void;
   expandedFolders: Set<string>;
   onToggleFolder: (path: string) => void;
 };
 
+// Individual row in the file tree. It renders both folders and files, then
+// recursively renders children when a folder is expanded.
 function TreeNodeRow({
   node,
   depth,
   path,
   activePath,
   onSelectFile,
+  onOpenFile,
   expandedFolders,
   onToggleFolder,
 }: TreeNodeRowProps) {
@@ -37,6 +42,11 @@ function TreeNodeRow({
   const isExpanded = expandedFolders.has(path);
   const label = isFolder ? `[folder] ${node.name}` : `[file] ${node.name}`;
 
+  // Used to separate single click from double click:
+  // single click previews a file after a short delay, while double click cancels
+  // that preview and opens the file as a normal/persistent tab.
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  
   return (
     <li>
       <button
@@ -48,11 +58,30 @@ function TreeNodeRow({
         } ${isFolder ? "font-semibold" : "font-normal"}`}
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={() => {
+          // Folders only expand/collapse. They do not open editor tabs.
           if (isFolder) {
             onToggleFolder(path);
-          } else {
-            onSelectFile(node, path);
+            return;
           }
+
+          if (clickTimerRef.current) {
+            clearTimeout(clickTimerRef.current);
+          }
+
+          clickTimerRef.current = setTimeout(() => {
+            onSelectFile(node, path);
+            clickTimerRef.current = null;
+          }, 200);
+        }}
+        onDoubleClick={() => {
+          if (isFolder) return;
+
+          if (clickTimerRef.current) {
+            clearTimeout(clickTimerRef.current);
+            clickTimerRef.current = null;
+          }
+
+          onOpenFile?.(node, path);
         }}
         aria-expanded={isFolder ? isExpanded : undefined}
       >
@@ -74,6 +103,7 @@ function TreeNodeRow({
               path={`${path}/${child.name}`}
               activePath={activePath}
               onSelectFile={onSelectFile}
+              onOpenFile={onOpenFile}
               expandedFolders={expandedFolders}
               onToggleFolder={onToggleFolder}
             />
@@ -85,6 +115,7 @@ function TreeNodeRow({
 }
 
 function getInitialExpandedFolders(nodes: TreeNode[], parentPath = ""): string[] {
+  // Expand all folders by default so the hardcoded demo tree is immediately visible.
   return nodes.flatMap((node) => {
     const path = parentPath ? `${parentPath}/${node.name}` : node.name;
 
@@ -96,11 +127,13 @@ function getInitialExpandedFolders(nodes: TreeNode[], parentPath = ""): string[]
   });
 }
 
-export function FileTree({ nodes, activePath, onSelectFile }: FileTreeProps) {
+export function FileTree({ nodes, activePath, onSelectFile, onOpenFile }: FileTreeProps) {
+  // Track expanded folders locally because folder open/closed UI belongs to the tree.
   const [expandedFolders, setExpandedFolders] = useState(
     () => new Set(getInitialExpandedFolders(nodes))
   );
 
+  // Toggle a folder path while preserving all other expanded/collapsed folders.
   const handleToggleFolder = (path: string) => {
     setExpandedFolders((current) => {
       const next = new Set(current);
@@ -116,6 +149,9 @@ export function FileTree({ nodes, activePath, onSelectFile }: FileTreeProps) {
   };
 
   return (
+    // File explorer section:
+    // --------------------------------------------------------------------------------
+    // Renders the project tree and delegates file selection/opening behavior to page.tsx.
     <nav aria-label="Project files">
       <ul className="space-y-0.5">
         {nodes.map((node) => (
@@ -126,6 +162,7 @@ export function FileTree({ nodes, activePath, onSelectFile }: FileTreeProps) {
             path={node.name}
             activePath={activePath}
             onSelectFile={onSelectFile}
+            onOpenFile={onOpenFile}
             expandedFolders={expandedFolders}
             onToggleFolder={handleToggleFolder}
           />

--- a/nimbus/components/TabBar.tsx
+++ b/nimbus/components/TabBar.tsx
@@ -15,11 +15,35 @@ type TabBarProps = {
 // This is a simple tab bar component that displays open files and their dirty state.
 // It also allows switching between files by clicking on the tabs.
 export function TabBar({ files, activeFileId, onSelectFile }: TabBarProps) {
+
+  // Helper to get files with duplicate names
+  const duplicatedNames = new Set(
+    files
+      .filter((file) =>
+        files.some((otherFile) =>
+          otherFile.id !== file.id && otherFile.name === file.name
+        )
+      )
+      .map((file) => file.name)
+  );
+
+  // Helper to get the folder path of a file
+  const getFolderPath = (file: OpenFileTab) => {
+    if (!file.id.endsWith(file.name)) {
+      return file.id;
+    }
+
+    return file.id.slice(0, -file.name.length);
+  };
+
   return (
     <div className="flex overflow-x-auto border-b border-neutral-800 bg-neutral-900">
       {/* Map through the files and create a tab for each one */}
       {files.map((file) => {
         const isActive = file.id === activeFileId;
+
+        const showPath = duplicatedNames.has(file.name);
+        const folderPath = getFolderPath(file);
 
         return (
           <button
@@ -35,6 +59,13 @@ export function TabBar({ files, activeFileId, onSelectFile }: TabBarProps) {
             ].join(" ")}
           >
             <span>{file.name}</span>
+
+            {showPath && folderPath ? (
+              <span className="text-xs text-neutral-500">
+                {folderPath}
+              </span>
+            ) : null}
+
             {file.isDirty ? <span>•</span> : null}
           </button>
         );

--- a/nimbus/components/TabBar.tsx
+++ b/nimbus/components/TabBar.tsx
@@ -1,0 +1,44 @@
+export type OpenFileTab = {
+  id: string;
+  name: string;
+  contents: string;
+  isDirty: boolean;
+  isPreview: boolean;
+};
+
+type TabBarProps = {
+  files: OpenFileTab[];
+  activeFileId: string;
+  onSelectFile: (id: string) => void;
+};
+
+// This is a simple tab bar component that displays open files and their dirty state.
+// It also allows switching between files by clicking on the tabs.
+export function TabBar({ files, activeFileId, onSelectFile }: TabBarProps) {
+  return (
+    <div className="flex overflow-x-auto border-b border-neutral-800 bg-neutral-900">
+      {/* Map through the files and create a tab for each one */}
+      {files.map((file) => {
+        const isActive = file.id === activeFileId;
+
+        return (
+          <button
+            key={file.id}
+            type="button"
+            onClick={() => onSelectFile(file.id)}
+            className={[
+              "h-10 shrink-0 px-4 text-sm border-r border-neutral-800",
+              "flex items-center gap-1",
+              isActive
+                ? "bg-neutral-800 text-white border-b-2 border-b-blue-500"
+                : "bg-neutral-900 text-neutral-400 hover:text-white",
+            ].join(" ")}
+          >
+            <span>{file.name}</span>
+            {file.isDirty ? <span>•</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
This should add a tab bar layout with basic functionalities to the current webpage. File tree's behaviors should now be quite the same as VS Code's file tree behaviors.