### PR TITLE
NIM-31: Context menu options for files, folders, and empty space

### DIFF
--- a/nimbus/components/ContextMenu.tsx
+++ b/nimbus/components/ContextMenu.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export type ContextMenuItem = {
+  label: string;
+  onClick: () => void;
+  destructive?: boolean;
+};
+type ContextMenuProps = {
+  items: ContextMenuItem[];
+  position: { x: number; y: number };
+  onClose: () => void;
+};
+
+export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLUListElement>(null);
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+  return (
+    <ul
+      ref={menuRef}
+      role="menu"
+      className="fixed z-50 min-w-[160px] rounded-md border border-neutral-800 bg-neutral-900 py-1 shadow-lg"
+      style={{ top: position.y, left: position.x }}
+    >
+      {items.map((item) => (
+        <li key={item.label} role="none">
+          <button
+            type="button"
+            role="menuitem"
+            className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-neutral-800 ${
+              item.destructive ? "text-red-400" : "text-neutral-200"
+            }`}
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
+          >
+            {item.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/nimbus/components/ContextMenu.tsx
+++ b/nimbus/components/ContextMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { Position } from "@/types/workspace";
 
 export type ContextMenuItem = {
   label: string;
@@ -8,12 +9,25 @@ export type ContextMenuItem = {
 };
 type ContextMenuProps = {
   items: ContextMenuItem[];
-  position: { x: number; y: number };
+  position: Position;
   onClose: () => void;
 };
 
+// Floating right-click menu used by the file explorer. The item list is
+// built by the caller (ExplorerPanel) for three targets:
+// - Files: Open, Rename, Duplicate, Delete
+// - Folders: New File, New Folder, Rename, Delete
+// - Empty panel space: New File, New Folder
+//
+// This component only handles presentation and dismissal (outside click,
+// Escape, or clicking an item) — it doesn't know what "target" it's for.
 export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLUListElement>(null);
+
+  // Start at the raw click point, then clamp on-screen below before paint.
+  const [adjustedPosition, setAdjustedPosition] = useState(position);
+
+  // Close on outside click or Escape, matching native context menu behavior.
   useEffect(() => {
     function handlePointerDown(event: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
@@ -32,12 +46,30 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [onClose]);
+
+  // Nudge the menu back on-screen if the click point would render it
+  // partially past the right or bottom edge of the viewport. Runs
+  // synchronously before paint so there's no visible jump.
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const { width, height } = menu.getBoundingClientRect();
+    const maxX = window.innerWidth - width;
+    const maxY = window.innerHeight - height;
+
+    setAdjustedPosition({
+      x: Math.max(0, Math.min(position.x, maxX)),
+      y: Math.max(0, Math.min(position.y, maxY)),
+    });
+  }, [position]);
+
   return (
     <ul
       ref={menuRef}
       role="menu"
       className="fixed z-50 min-w-[160px] rounded-md border border-neutral-800 bg-neutral-900 py-1 shadow-lg"
-      style={{ top: position.y, left: position.x }}
+      style={{ top: adjustedPosition.y, left: adjustedPosition.x }}
     >
       {items.map((item) => (
         <li key={item.label} role="none">

--- a/nimbus/components/ExplorerPanel.test.tsx
+++ b/nimbus/components/ExplorerPanel.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ExplorerPanel } from "./ExplorerPanel";
+import type { TreeNode } from "@/types/workspace";
+
+/**
+ * ExplorerPanel owns the right-click context menu for the file explorer.
+ * These tests guard the three menu variants from the NIM-31 acceptance
+ * criteria: file rows, folder rows, and empty sidebar space each show a
+ * different set of actions, and picking an action closes the menu.
+ */
+const nodes: TreeNode[] = [
+  { name: "package.json", type: "file", content: "{}" },
+  {
+    name: "app",
+    type: "folder",
+    children: [{ name: "page.tsx", type: "file", content: "" }],
+  },
+];
+
+function renderPanel() {
+  return render(
+    <ExplorerPanel
+      nodes={nodes}
+      isLoading={false}
+      error={null}
+      onSelectFile={vi.fn()}
+      onOpenFile={vi.fn()}
+    />,
+  );
+}
+
+describe("ExplorerPanel context menu", () => {
+  it("shows Open, Rename, Duplicate, Delete when right-clicking a file row", () => {
+    renderPanel();
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: /package\.json/ }),
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Open" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Rename" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Duplicate" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows New File, New Folder, Rename, Delete when right-clicking a folder row", () => {
+    renderPanel();
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: /app/ }));
+
+    expect(
+      screen.getByRole("menuitem", { name: "New File" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "New Folder" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Rename" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows New File, New Folder when right-clicking empty sidebar space", () => {
+    renderPanel();
+
+    fireEvent.contextMenu(screen.getByText("Explorer"));
+
+    expect(
+      screen.getByRole("menuitem", { name: "New File" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "New Folder" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Open" })).toBeNull();
+  });
+
+  it("does not also open the empty-space menu when a row is right-clicked", () => {
+    renderPanel();
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: /package\.json/ }),
+    );
+
+    // Only one menu should be open: the file menu, not the empty-space menu.
+    expect(screen.getAllByRole("menu")).toHaveLength(1);
+    expect(screen.getByRole("menuitem", { name: "Open" })).toBeInTheDocument();
+  });
+
+  it("closes the menu after clicking an item", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: /package\.json/ }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Open" }));
+
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/nimbus/components/ExplorerPanel.tsx
+++ b/nimbus/components/ExplorerPanel.tsx
@@ -1,5 +1,5 @@
 import { FileTree } from "@/components/FileTree";
-import type { TreeNode } from "@/types/workspace";
+import type { ContextMenuHandler, Position, TreeNode } from "@/types/workspace";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { useState } from "react";
 
@@ -24,16 +24,18 @@ export function ExplorerPanel({
   onSelectFile,
   onOpenFile,
 }: ExplorerPanelProps) {
+  // Right-click menu state. Any of the three handlers below can set this;
+  // rendering a single <ContextMenu> instance for whichever target was
+  // clicked keeps only one menu open at a time.
   const [contextMenu, setContextMenu] = useState<{
     items: ContextMenuItem[];
-    position: { x: number; y: number };
+    position: Position;
   } | null>(null);
 
-  function handleFileContextMenu(
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) {
+  // Item list for right-clicking a file row. Actions are placeholder
+  // console.log calls for now — wiring them to real file operations is a
+  // separate issue.
+  const handleFileContextMenu: ContextMenuHandler = (node, path, position) => {
     setContextMenu({
       position,
       items: [
@@ -47,13 +49,14 @@ export function ExplorerPanel({
         },
       ],
     });
-  }
+  };
 
-  function handleFolderContextMenu(
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) {
+  // Item list for right-clicking a folder row.
+  const handleFolderContextMenu: ContextMenuHandler = (
+    node,
+    path,
+    position,
+  ) => {
     setContextMenu({
       position,
       items: [
@@ -70,8 +73,11 @@ export function ExplorerPanel({
         },
       ],
     });
-  }
+  };
 
+  // Item list for right-clicking empty sidebar space (not a file/folder
+  // row). Rows call stopPropagation() on their own onContextMenu, so this
+  // only fires when the click doesn't land on the tree.
   function handleEmptyContextMenu(event: React.MouseEvent<HTMLElement>) {
     event.preventDefault();
     setContextMenu({

--- a/nimbus/components/ExplorerPanel.tsx
+++ b/nimbus/components/ExplorerPanel.tsx
@@ -1,5 +1,7 @@
 import { FileTree } from "@/components/FileTree";
 import type { TreeNode } from "@/types/workspace";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { useState } from "react";
 
 type ExplorerPanelProps = {
   nodes: TreeNode[];
@@ -22,8 +24,76 @@ export function ExplorerPanel({
   onSelectFile,
   onOpenFile,
 }: ExplorerPanelProps) {
+  const [contextMenu, setContextMenu] = useState<{
+    items: ContextMenuItem[];
+    position: { x: number; y: number };
+  } | null>(null);
+
+  function handleFileContextMenu(
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) {
+    setContextMenu({
+      position,
+      items: [
+        { label: "Open", onClick: () => console.log("Open", path) },
+        { label: "Rename", onClick: () => console.log("Rename", path) },
+        { label: "Duplicate", onClick: () => console.log("Duplicate", path) },
+        {
+          label: "Delete",
+          onClick: () => console.log("Delete", path),
+          destructive: true,
+        },
+      ],
+    });
+  }
+
+  function handleFolderContextMenu(
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) {
+    setContextMenu({
+      position,
+      items: [
+        { label: "New File", onClick: () => console.log("New File", path) },
+        {
+          label: "New Folder",
+          onClick: () => console.log("New Folder", path),
+        },
+        { label: "Rename", onClick: () => console.log("Rename", path) },
+        {
+          label: "Delete",
+          onClick: () => console.log("Delete", path),
+          destructive: true,
+        },
+      ],
+    });
+  }
+
+  function handleEmptyContextMenu(event: React.MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    setContextMenu({
+      position: { x: event.clientX, y: event.clientY },
+      items: [
+        {
+          label: "New File",
+          onClick: () => console.log("New File at root"),
+        },
+        {
+          label: "New Folder",
+          onClick: () => console.log("New Folder at root"),
+        },
+      ],
+    });
+  }
+
   return (
-    <aside className="w-[15vw] shrink-0 bg-neutral-900 text-neutral-100">
+    <aside
+      className="w-[15vw] shrink-0 bg-neutral-900 text-neutral-100"
+      onContextMenu={handleEmptyContextMenu}
+    >
       <header className="h-12 px-4 flex items-center border-b border-neutral-800">
         Explorer
       </header>
@@ -38,8 +108,18 @@ export function ExplorerPanel({
           activePath={activePath}
           onSelectFile={onSelectFile}
           onOpenFile={onOpenFile}
+          onFileContextMenu={handleFileContextMenu}
+          onFolderContextMenu={handleFolderContextMenu}
         />
       )}
+
+      {contextMenu ? (
+        <ContextMenu
+          position={contextMenu.position}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
     </aside>
   );
 }

--- a/nimbus/components/FileTree.tsx
+++ b/nimbus/components/FileTree.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { File, FileCode, FileJson, Folder } from "lucide-react";
-import type { TreeNode } from "@/types/workspace";
+import type { ContextMenuHandler, TreeNode } from "@/types/workspace";
 
 export type { TreeNode } from "@/types/workspace";
 
@@ -9,16 +9,10 @@ type FileTreeProps = {
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
   onOpenFile?: (node: TreeNode, path: string) => void;
-  onFileContextMenu?: (
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) => void;
-  onFolderContextMenu?: (
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) => void;
+  // Right-click on a row. The parent (ExplorerPanel) decides what menu
+  // items to show based on whether the row is a file or a folder.
+  onFileContextMenu?: ContextMenuHandler;
+  onFolderContextMenu?: ContextMenuHandler;
 };
 
 type TreeNodeRowProps = {
@@ -28,16 +22,8 @@ type TreeNodeRowProps = {
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
   onOpenFile?: (node: TreeNode, path: string) => void;
-  onFileContextMenu?: (
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) => void;
-  onFolderContextMenu?: (
-    node: TreeNode,
-    path: string,
-    position: { x: number; y: number },
-  ) => void;
+  onFileContextMenu?: ContextMenuHandler;
+  onFolderContextMenu?: ContextMenuHandler;
   expandedFolders: Set<string>;
   onToggleFolder: (path: string) => void;
 };
@@ -131,6 +117,8 @@ function TreeNodeRow({
         }}
         onContextMenu={(event) => {
           event.preventDefault();
+          // stopPropagation so ExplorerPanel's empty-space handler doesn't
+          // also fire for a click that landed on a row.
           event.stopPropagation();
 
           const position = { x: event.clientX, y: event.clientY };

--- a/nimbus/components/FileTree.tsx
+++ b/nimbus/components/FileTree.tsx
@@ -9,6 +9,16 @@ type FileTreeProps = {
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
   onOpenFile?: (node: TreeNode, path: string) => void;
+  onFileContextMenu?: (
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) => void;
+  onFolderContextMenu?: (
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) => void;
 };
 
 type TreeNodeRowProps = {
@@ -18,6 +28,16 @@ type TreeNodeRowProps = {
   activePath?: string;
   onSelectFile: (node: TreeNode, path: string) => void;
   onOpenFile?: (node: TreeNode, path: string) => void;
+  onFileContextMenu?: (
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) => void;
+  onFolderContextMenu?: (
+    node: TreeNode,
+    path: string,
+    position: { x: number; y: number },
+  ) => void;
   expandedFolders: Set<string>;
   onToggleFolder: (path: string) => void;
 };
@@ -56,6 +76,8 @@ function TreeNodeRow({
   activePath,
   onSelectFile,
   onOpenFile,
+  onFileContextMenu,
+  onFolderContextMenu,
   expandedFolders,
   onToggleFolder,
 }: TreeNodeRowProps) {
@@ -107,6 +129,18 @@ function TreeNodeRow({
 
           onOpenFile?.(node, path);
         }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          const position = { x: event.clientX, y: event.clientY };
+
+          if (isFolder) {
+            onFolderContextMenu?.(node, path, position);
+          } else {
+            onFileContextMenu?.(node, path, position);
+          }
+        }}
         aria-expanded={isFolder ? isExpanded : undefined}
       >
         <span className="mr-2 flex h-4 w-4 items-center justify-center">
@@ -131,6 +165,8 @@ function TreeNodeRow({
               activePath={activePath}
               onSelectFile={onSelectFile}
               onOpenFile={onOpenFile}
+              onFileContextMenu={onFileContextMenu}
+              onFolderContextMenu={onFolderContextMenu}
               expandedFolders={expandedFolders}
               onToggleFolder={onToggleFolder}
             />
@@ -162,6 +198,8 @@ export function FileTree({
   activePath,
   onSelectFile,
   onOpenFile,
+  onFileContextMenu,
+  onFolderContextMenu,
 }: FileTreeProps) {
   // Track expanded folders locally because folder open/closed UI belongs to the tree.
   const [expandedFolders, setExpandedFolders] = useState(
@@ -188,11 +226,7 @@ export function FileTree({
       return next;
     });
   };
-
   return (
-    // File explorer section:
-    // --------------------------------------------------------------------------------
-    // Renders the project tree and delegates file selection/opening behavior to page.tsx.
     <nav aria-label="Project files">
       <ul className="space-y-0.5">
         {nodes.map((node) => (
@@ -204,6 +238,8 @@ export function FileTree({
             activePath={activePath}
             onSelectFile={onSelectFile}
             onOpenFile={onOpenFile}
+            onFileContextMenu={onFileContextMenu}
+            onFolderContextMenu={onFolderContextMenu}
             expandedFolders={expandedFolders}
             onToggleFolder={handleToggleFolder}
           />

--- a/nimbus/types/workspace.ts
+++ b/nimbus/types/workspace.ts
@@ -43,3 +43,19 @@ export type WorkspaceFileResponse = {
   name: string;
   content: string;
 };
+
+// Viewport coordinates for a floating UI element (currently just the
+// right-click context menu).
+export type Position = {
+  x: number;
+  y: number;
+};
+
+// Right-click handler for a file/folder tree row. Shared by FileTree (which
+// calls it) and ExplorerPanel (which implements it) so the signature only
+// needs to change in one place.
+export type ContextMenuHandler = (
+  node: TreeNode,
+  path: string,
+  position: Position,
+) => void;


### PR DESCRIPTION
## Summary
- Add a reusable `ContextMenu` component (floating menu, closes on outside-click/Escape)
- Right-click on a file row shows Open, Rename, Duplicate, Delete
- Right-click on a folder row shows New File, New Folder, Rename, Delete
- Right-click on empty sidebar space shows New File, New Folder
- Menu actions are wired to placeholder console.log callbacks — backend integration is a separate issue per the ticket

## Test plan
- [x] npx tsc --noEmit passes
- [x] npx eslint passes on changed files
- [x] Manual browser check: right-click each of the three targets (file, folder, empty space) and confirm the correct items appear and log to the console